### PR TITLE
feat (skin-missing island): More greens on settings

### DIFF
--- a/app/javascript/styles/missing-island/diff.scss
+++ b/app/javascript/styles/missing-island/diff.scss
@@ -77,6 +77,20 @@ body.lighter {
   background-color: $green;
 }
 
+.prose a,
+.account__header__bio .account__header__fields a {
+  color: #34842d;
+}
+
+.prose a:active,
+.prose a:focus,
+.prose a:hover,
+.account__header__bio .account__header__fields a:active,
+.account__header__bio .account__header__fields a:focus,
+.account__header__bio .account__header__fields a:hover {
+  color: #3bc62b;
+}
+
 .admin-wrapper {
   background-color: #b1ed9b;
 }
@@ -233,6 +247,20 @@ a.active::before {
 .switch-to-advanced {
   background-color: #dae8d9;
   color: #4c5d44;
+}
+
+.column-back-button {
+  color: #41891f;
+}
+
+.account__domain-pill {
+  background: rgba(36,105,39,.2);
+  color: #2d7f3c;
+}
+
+.check-box__input.checked:before,
+.radio-button__input.checked:before {
+  background: #3dbf3b;
 }
 
 .load-more:hover {

--- a/app/javascript/styles/missing-island/diff.scss
+++ b/app/javascript/styles/missing-island/diff.scss
@@ -77,6 +77,18 @@ body.lighter {
   background-color: $green;
 }
 
+.admin-wrapper {
+  background-color: #b1ed9b;
+}
+
+.flash-message {
+  background-color:#45e439;
+}
+
+.admin-wrapper .sidebar ul ul {
+  background-color: #e6ebf070;
+}
+
 .button:disabled,
 .button:disabled:hover,
 .poll__chart,

--- a/app/javascript/styles/missing-island/diff.scss
+++ b/app/javascript/styles/missing-island/diff.scss
@@ -78,7 +78,8 @@ body.lighter {
 }
 
 .prose a,
-.account__header__bio .account__header__fields a {
+.account__header__bio .account__header__fields a,
+.status__wraper-direct .status__prepend {
   color: #34842d;
 }
 


### PR DESCRIPTION
### Changes | 변경 사항
- 설정 페이지에 기본값 대신 초록색 팔레트 적용
- 인스턴스 버튼, 링크, 이전 버튼, 체크박스 및 라디오 버튼에 초록색 팔레트 적용 (1차)
- 개인적인 멘션 인디케이터에 초록색 팔레트 적용

### Effects | 영향
- Missing Island (잃어버린 섬) 스킨에 파란색-회백색 계열의 기본 팔레트를 사용하는 부분이 더 적어집니다
  - 설정 페이지를 누가 신경이나 쓰겠냐만은 어쨌든 그렇습니다